### PR TITLE
Add API Response Caching & Revalidation

### DIFF
--- a/app/api/rss/route.ts
+++ b/app/api/rss/route.ts
@@ -3,6 +3,9 @@ import Parser from 'rss-parser';
 
 const parser = new Parser();
 
+// Revalidate every 5 minutes (300 seconds)
+export const revalidate = 300;
+
 export interface RSSItem {
   title: string;
   link: string;


### PR DESCRIPTION
## Summary
Implements API response caching with 5-minute revalidation to improve performance and reduce server load.

## Changes
- Added `export const revalidate = 300;` to API route
- Enables Next.js automatic caching for RSS feed responses
- Cache revalidates every 5 minutes (300 seconds)

## Benefits
- ✅ Faster response times for users
- ✅ Reduced load on CBC's servers
- ✅ Better user experience
- ✅ Lower hosting costs

## Testing
- ✅ All tests passing
- ✅ Build succeeds
- ✅ No breaking changes

## Related
Closes #3

Part of Phase 2 (Performance) improvements.